### PR TITLE
Calling button.Focus() does not actually result in events being parse…

### DIFF
--- a/window.go
+++ b/window.go
@@ -26,7 +26,11 @@ func NewWindow(id string) *Window {
 }
 
 func (win *Window) SetFocussedControl(ctrl Control) {
-	win.focussedControl = ctrl
+	for _, loopFC := range win.getControlsDeep() {
+		if loopFC.ID() == ctrl.ID() {
+			win.focussedControl = loopFC
+		}
+	}
 }
 
 func (win *Window) FocussedControl() Control {


### PR DESCRIPTION
…d by the button. The reason is that ParseEvent is being called on the baseControl and not on the button. This fixes it.
